### PR TITLE
Fix blog link for local development

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,9 @@ function App() {
         <div className="Blog" id = "Blog">
           <h2>Latest Posts</h2>
           <p>
-            <a href="/blog/">Visit the Blog</a>
+            <a href={import.meta.env.DEV ? 'http://localhost:4321/' : '/blog/'}>
+              Visit the Blog
+            </a>
           </p>
         </div>
         <div className="About" id="About">


### PR DESCRIPTION
## Summary
- use a dev-friendly link to the Astro blog so it works when running `vite` locally

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68829c8e7bc8832c982a6968569f6873