### PR TITLE
Fix blog integration and embed via iframe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist-ssr
 *.sln
 *.sw?
 blog/node_modules
+blog/.astro

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import './App.css'
 import React, { useState, useEffect } from 'react';
 import Home from './Home.tsx'
+import Blog from './Blog.tsx'
 
 function App() {
   const [isScrolled, setIsScrolled] = useState(false);
@@ -32,11 +33,7 @@ function App() {
         </div>
         <div className="Blog" id = "Blog">
           <h2>Latest Posts</h2>
-          <p>
-            <a href={import.meta.env.DEV ? 'http://localhost:4321/' : '/blog/'}>
-              Visit the Blog
-            </a>
-          </p>
+          <Blog />
         </div>
         <div className="About" id="About">
           <h2>About Me</h2>

--- a/src/Blog.tsx
+++ b/src/Blog.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+/**
+ * Blog component embeds the Astro-generated blog.
+ * During development the blog runs on a separate dev server,
+ * so we point the iframe to that address. In production the
+ * blog is served from the /blog/ path of the built site.
+ */
+function Blog() {
+  const src = import.meta.env.DEV ? 'http://localhost:4321/blog/' : '/blog/';
+  return (
+    <iframe
+      title="Blog"
+      src={src}
+      style={{ width: '100%', height: '80vh', border: 'none' }}
+    />
+  );
+}
+
+export default Blog;


### PR DESCRIPTION
## Summary
- embed Astro blog within React site
- add development/production iframe logic
- ignore Astro build artifacts

## Testing
- `npm run build`
- `npm run dev:all` (then exited)

------
https://chatgpt.com/codex/tasks/task_e_6883df1096ec832cb52d6749622b98d6