### PR TITLE
Integrate Astro blog

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "npm run build:blog && vite build",
+    "build:blog": "cd astro-blog && npm install && npm run build && rm -rf ../public/blog && cp -r dist ../public/blog",
     "preview": "vite preview",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist"

--- a/src/Blog.tsx
+++ b/src/Blog.tsx
@@ -15,6 +15,9 @@ function Blog() {
           <p>{post.content}</p>
         </article>
       ))}
+      <p>
+        Read more on my <a href="/blog/">Astro blog</a>.
+      </p>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- build Astro blog as part of the main build
- copy blog build output to the `public` folder
- link to the blog from the Blog component

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68869811657c832ca443751df09ad6cc