### PR TITLE
Fix build script and site config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+.astro
+public/blog/
 *.local
 
 # Editor directories and files

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,3 +1,6 @@
 import { defineConfig } from 'astro/config';
+
 // https://astro.build/config
-export default defineConfig({});
+export default defineConfig({
+  site: 'https://anuj-nk.github.io',
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "npm run build:blog && astro build",
-    "build:blog": "cd astro-blog && npm install && npm run build && rm -rf ../public/blog && cp -r dist ../public/blog",
+    "build:blog": "cd astro-blog && npm install && npm run build && mkdir -p ../public && rm -rf ../public/blog && cp -r dist ../public/blog",
     "preview": "astro preview",
     "astro": "astro",
     "predeploy": "npm run build",


### PR DESCRIPTION
## Summary
- set `site` for the root Astro config so deployment links work
- create a `public` folder tracked with a `.gitkeep`
- make the blog build script create the `public` folder
- ignore Astro build artifacts

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6886b483d44c832caa64ef70ff17257f